### PR TITLE
allow for custom weights; normalize before augmentation

### DIFF
--- a/unet2d/data.py
+++ b/unet2d/data.py
@@ -10,12 +10,12 @@ class AugTransform:
         self.aug = aug
 
     def __call__(self, x, y_true):
+        # normalize
+        x = normalize(x)
+
         # augment
         y_true = ia.SegmentationMapsOnImage(y_true, shape=y_true.shape)
         x_aug, y_true_aug = self.aug(image=x, segmentation_maps=y_true)
-
-        # normalize
-        x_aug = normalize(x_aug)
 
         # reshape
         x_aug = np.expand_dims(x_aug, 0).astype(np.float32)
@@ -23,24 +23,38 @@ class AugTransform:
 
         return {"x": x_aug, "y_true": y_true_aug}
 
+# Note: tfelt additions are reverse compatible
+#       they just allow for custom weights (func on init)
+#       and also normalize before augmentation so contrast augs work
+#        (even tho test data is also normalized, better to learn a wider range)
 class AugTransformConstantPosWeights:
     """creates weights with foreground to 1 * pos_weight and background to 1"""
-    def __init__(self, aug, pos_weight):
+    def __init__(self, aug, pos_weight, weights_func=None):
         self.aug = aug
         self.pos_weight = pos_weight
+        if weights_func is None:          # tfelt addition
+            self.w_func = default_weights #
+        else:                             #
+            self.w_func = weights_func    #
+
+    # tfelt addition
+    def default_weights(w, x, y):
+        weights = w * (y_true_aug > 0).astype(np.float32) +1
+        return weights
 
     def __call__(self, x, y_true):
+        # normalize
+        x = normalize(x)
+
         # augment
         y_true = ia.SegmentationMapsOnImage(y_true, shape=y_true.shape)
         x_aug, y_true_aug = self.aug(image=x, segmentation_maps=y_true)
 
-        # normalize
-        x_aug = normalize(x_aug)
-
         # reshape
         x_aug = np.expand_dims(x_aug, 0).astype(np.float32)
         y_true_aug = np.expand_dims(y_true_aug.arr[:, :, 0], 0).astype(np.float32)
-        weights = self.pos_weight * (y_true_aug > 0).astype(np.float32) + 1
+        #weights = self.pos_weight * (y_true_aug > 0).astype(np.float32) + 1
+        weights = self.w_func(self.pos_weight, x_aug, y_true_aug) # tfelt addition
 
         return {"x": x_aug, "y_true": y_true_aug, "weights": weights}
 
@@ -49,12 +63,12 @@ class AugTransformMultiClass:
         self.aug = aug
 
     def __call__(self, x, y_true):
+        # normalize
+        x = normalize(x)
+
         # augment
         y_true = ia.SegmentationMapsOnImage(y_true, shape=y_true.shape)
         x_aug, y_true_aug = self.aug(image=x, segmentation_maps=y_true)
-
-        # normalize
-        x_aug = normalize(x_aug)
 
         # reshape
         x_aug = np.expand_dims(x_aug, 0).astype(np.float32)


### PR DESCRIPTION
Adds a custom weights option specifically to class `AugTransformConstantPosWeights`. Normalizes training input data before augmentation to allow for contrast augmentations; does this in all classes.

To be added to a develop branch in the main repository